### PR TITLE
{fix} - taskDefinition.json log group nameing\n #40

### DIFF
--- a/deployment/taskDefinition.json
+++ b/deployment/taskDefinition.json
@@ -58,7 +58,7 @@
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
-                    "awslogs-group": "ecs-idea-__ENV__frog",
+                    "awslogs-group": "ecs-idea-__ENV___frog",
                     "awslogs-region": "__REGION__"
                 }
             },


### PR DESCRIPTION
태스크정의 로그 네이밍 잘못 지정
