### PR TITLE
{improvement} - 함께하기, 방생성, 매칭에 재접속 로직 추가 \n #478

### DIFF
--- a/src/features/v2ws/joinPlayEventWebsocketHandler.go
+++ b/src/features/v2ws/joinPlayEventWebsocketHandler.go
@@ -61,6 +61,17 @@ func joinPlay(c echo.Context) error {
 		fmt.Printf("Failed to parse token: %v\n", err)
 		return nil
 	}
+	// 재접속 확인
+	// 유저 상태가 abnormal 이면 해당 roomID를 가지고 온다.
+	if req.SessionID != "" {
+		roomID, _ := repository.JoinRedisSessionGet(context.Background(), req.SessionID)
+		if roomID != 0 {
+			// 기존 연결 복구
+			restoreSession(ws, req.SessionID, roomID, userID)
+			// 연결한 유저에게 메시지 정보를 전달해야 된다.
+			return nil
+		}
+	}
 
 	// 비즈니스 로직
 	// 대기중인 방이 있는지 체크
@@ -127,80 +138,15 @@ func joinPlay(c echo.Context) error {
 		return nil
 	}
 
-	defer ws.Close()
-
 	// sessionID 생성
 	sessionID := generateSessionID()
-
-	// 초기 메시지 처리
-	var initialMsg entity.WSMessage
-	err = ws.ReadJSON(&initialMsg)
+	// 세션 ID 저장
+	err = repository.PlayTogetherRedisSessionSet(ctx, sessionID, roomID)
 	if err != nil {
-		fmt.Printf("Failed to read initial message: %v\n", err)
+		fmt.Printf("Failed to save session: %v\n", err)
 		return nil
 	}
 
-	initialMsg.UserID = userID
-	initialMsg.RoomID = roomID
-	initialMsg.SessionID = sessionID
-
-	// 첫 번째 레벨 맵 초기화 (RoomSessions)
-	if entity.RoomSessions == nil {
-		entity.RoomSessions = make(map[uint][]string)
-	}
-
-	// 두 번째 레벨 맵 초기화 (WSClients)
-	if entity.WSClients == nil {
-		entity.WSClients = make(map[string]*entity.WSClient)
-	}
-
-	// 방 세션에 sessionID 추가
-	entity.RoomSessions[roomID] = append(entity.RoomSessions[roomID], sessionID)
-
-	// sessionID를 WSClients에 등록
-	wsClient := &entity.WSClient{
-		RoomID:    roomID,
-		UserID:    userID,
-		SessionID: sessionID,
-		Conn:      ws,
-		Closed:    false,
-	}
-	entity.WSClients[sessionID] = wsClient
-
-	// 메시지 브로드캐스트
-	entity.WSBroadcast <- initialMsg
-
-	// Ping/Pong 관리 시작
-	go HandlePingPong(wsClient)
-
-	// 메시지 수신 루프
-	for {
-		var msg entity.WSMessage
-		err := ws.ReadJSON(&msg)
-		if err != nil {
-			fmt.Printf("Error reading message for session %s: %v\n", sessionID, err)
-
-			// 비정상 종료 처리
-			wsClient.Closed = true
-			AbnormalErrorHandling(roomID, sessionID)
-			break
-		}
-
-		// 메시지 처리
-		msg.RoomID = roomID
-		msg.UserID = userID
-		msg.SessionID = sessionID
-		entity.WSBroadcast <- msg
-	}
-
-	// 연결 종료 및 클라이언트 정리
-	delete(entity.WSClients, sessionID)
-	removeSessionFromRoom(roomID, sessionID)
-
-	if len(entity.RoomSessions[roomID]) == 0 {
-		delete(entity.RoomSessions, roomID)
-		fmt.Printf("Room %d deleted as it is empty.\n", roomID)
-	}
-
+	registerNewSession(ws, sessionID, roomID, userID)
 	return nil
 }

--- a/src/features/v2ws/model/request/joinPlayEvent.go
+++ b/src/features/v2ws/model/request/joinPlayEvent.go
@@ -1,8 +1,9 @@
 package request
 
 type ReqWSJoinPlay struct {
-	Tkn      string `query:"tkn" validate:"required"`
-	Password string `query:"password" validate:"required"`
+	Tkn       string `query:"tkn" validate:"required"`
+	Password  string `query:"password" validate:"required"`
+	SessionID string `query:"sessionID"`
 }
 
 type ReqWSJoinPlayEvent struct {

--- a/src/features/v2ws/playTogetherEventWebsocketUseCase.go
+++ b/src/features/v2ws/playTogetherEventWebsocketUseCase.go
@@ -26,6 +26,7 @@ func CreatePlayTogetherRoomDTO(uID uint, count int, timer int, password string) 
 		PlayTurn:     0,
 		Name:         "play together",
 		Password:     password,
+		StartTime:    time.Now(),
 	}
 	return result
 }

--- a/src/features/v2ws/repository/joinPlayEvenetWebsocketRepository.go
+++ b/src/features/v2ws/repository/joinPlayEvenetWebsocketRepository.go
@@ -7,6 +7,8 @@ import (
 	_errors "main/features/v2ws/model/errors"
 	"main/utils"
 	"main/utils/db/mysql"
+	_redis "main/utils/db/redis"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -151,6 +153,24 @@ func JoinInsertOneUserItem(ctx context.Context, tx *gorm.DB, userItemDTO mysql.U
 	}
 	if result.Error != nil {
 		return fmt.Errorf("유저 아이템 생성 실패: %v", result.Error)
+	}
+	return nil
+}
+
+func JoinRedisSessionGet(ctx context.Context, sessionID string) (uint, error) {
+	redisKey := fmt.Sprintf("abnormal_session:%s", sessionID)
+	roomID, err := _redis.Client.Get(ctx, redisKey).Uint64()
+	if err != nil {
+		return 0, nil
+	}
+	return uint(roomID), nil
+}
+
+func JoinRedisSessionSet(ctx context.Context, sessionID string, roomID uint) error {
+	redisKey := fmt.Sprintf("abnormal_session:%s", sessionID)
+	err := _redis.Client.Set(ctx, redisKey, roomID, 3*time.Minute).Err()
+	if err != nil {
+		return fmt.Errorf("세션 저장 실패: %v", err)
 	}
 	return nil
 }

--- a/src/features/v2ws/repository/playTogetherEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/playTogetherEventWebsocketRepository.go
@@ -8,6 +8,8 @@ import (
 	"main/features/v2ws/model/request"
 	"main/utils"
 	"main/utils/db/mysql"
+	_redis "main/utils/db/redis"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -193,6 +195,23 @@ func PlayTogetherInsertOneUserItem(ctx context.Context, tx *gorm.DB, userItemDTO
 	}
 	if result.Error != nil {
 		return fmt.Errorf("유저 아이템 생성 실패: %v", result.Error)
+	}
+	return nil
+}
+func PlayTogetherRedisSessionGet(ctx context.Context, sessionID string) (uint, error) {
+	redisKey := fmt.Sprintf("abnormal_session:%s", sessionID)
+	roomID, err := _redis.Client.Get(ctx, redisKey).Uint64()
+	if err != nil {
+		return 0, nil
+	}
+	return uint(roomID), nil
+}
+
+func PlayTogetherRedisSessionSet(ctx context.Context, sessionID string, roomID uint) error {
+	redisKey := fmt.Sprintf("abnormal_session:%s", sessionID)
+	err := _redis.Client.Set(ctx, redisKey, roomID, 3*time.Minute).Err()
+	if err != nil {
+		return fmt.Errorf("세션 저장 실패: %v", err)
 	}
 	return nil
 }

--- a/src/features/v2ws/usecase.go
+++ b/src/features/v2ws/usecase.go
@@ -442,6 +442,7 @@ func registerNewSession(ws *websocket.Conn, sessionID string, roomID uint, userI
 // 메시지 읽기 및 처리
 func readMessages(ws *websocket.Conn, sessionID string, roomID uint, userID uint) {
 	client := entity.WSClients[sessionID]
+	fmt.Println(client)
 	defer func() {
 		// 연결 종료 시 세션 정리
 		client.Closed = true


### PR DESCRIPTION
This pull request introduces several changes to improve session handling and refactor the WebSocket event handlers in the `v2ws` feature. The most important changes include adding session restoration logic, refactoring session registration, and updating the request and repository layers to support Redis operations.

### Session Handling Improvements:
* Added logic to check for existing sessions and restore them if the user reconnects in `joinPlayEventWebsocketHandler.go`.
* Refactored session registration and message handling logic into a new function `registerNewSession` in `joinPlayEventWebsocketHandler.go` and `playTogetherEventWebsocketHandler.go` [[1]](diffhunk://#diff-249614348e23304c6250b11ad54f0274b0ba3a65287cea82688471b92f06bdc9L130-R150) [[2]](diffhunk://#diff-fae2e2a295c2b1b12c6c0bf89a4d645cdeb971f21bc15441a2c92d6be5706f11L128-R137).

### Request and Repository Updates:
* Added `SessionID` field to `ReqWSJoinPlay` struct in `joinPlayEvent.go` to support session restoration.
* Introduced Redis operations for session handling in `joinPlayEvenetWebsocketRepository.go` and `playTogetherEventWebsocketRepository.go` [[1]](diffhunk://#diff-ed3f66557f0c3a2c751bef7b9cdb0bbab87a3cc69a3241e611fb4b005369e50cR159-R176) [[2]](diffhunk://#diff-577129ef00584ed09bbe14d13f0e0cbabfe78bd85e45d4fe32ebe3f018ed54b4R201-R217).

### Miscellaneous:
* Added `StartTime` field to `CreatePlayTogetherRoomDTO` function in `playTogetherEventWebsocketUseCase.go`.
* Imported necessary packages for Redis operations in repository files [[1]](diffhunk://#diff-ed3f66557f0c3a2c751bef7b9cdb0bbab87a3cc69a3241e611fb4b005369e50cR10-R11) [[2]](diffhunk://#diff-577129ef00584ed09bbe14d13f0e0cbabfe78bd85e45d4fe32ebe3f018ed54b4R11-R12).