### PR TITLE
{improvement} - 비정상 종료시 유저 상태 변경 및 에러 메시지 전송 완료 \n #477

### DIFF
--- a/src/features/v2ws/abnormalEventWebsocket.go
+++ b/src/features/v2ws/abnormalEventWebsocket.go
@@ -14,20 +14,20 @@ import (
 var reconnectTimers sync.Map // 재접속 타이머를 관리하는 맵
 
 // 비정상적인 에러를 처리하는 함수
-func AbnormalErrorHandling(roomID uint, sessionID string) {
+func AbnormalErrorHandling(roomID, userID uint, sessionID string) {
 	ctx := context.TODO()
 	roomInfoMsg := entity.RoomInfo{}
 	preloadUsers := []entity.RoomUsers{}
-
 	// 비정상적인 유저 상태 처리
 	err := mysql.Transaction(mysql.GormMysqlDB, func(tx *gorm.DB) error {
 		abnormalEntity := entity.WSAbnormalEntity{
 			RoomID:         roomID,
+			UserID:         userID,
 			AbnormalUserID: getUserIDFromSessionID(sessionID),
 		}
 
 		// 유저 상태 변경
-		if err := repository.AbnormalUpdateUsers(ctx, tx, &abnormalEntity); err != nil {
+		if err := repository.AbnormalUpdateRoomUsers(ctx, tx, &abnormalEntity); err != nil {
 			return err
 		}
 

--- a/src/features/v2ws/joinPlayEventWebsocketHandler.go
+++ b/src/features/v2ws/joinPlayEventWebsocketHandler.go
@@ -111,7 +111,7 @@ func joinPlay(c echo.Context) error {
 		}
 
 		// 방 유저 정보 추가
-		roomUserDTO := CreateMatchRoomUserDTO(userID, int(roomID), "ready")
+		roomUserDTO := CreateMatchRoomUserDTO(userID, int(roomID))
 		err = repository.JoinPlayInsertOneRoomUser(ctx, tx, roomUserDTO)
 		if err != nil {
 			return err

--- a/src/features/v2ws/matchEventWebsocketHandler.go
+++ b/src/features/v2ws/matchEventWebsocketHandler.go
@@ -97,7 +97,7 @@ func match(c echo.Context) error {
 		}
 
 		// room_user 생성
-		roomUserDTO := CreateMatchRoomUserDTO(userID, int(roomID), "ready")
+		roomUserDTO := CreateMatchRoomUserDTO(userID, int(roomID))
 		err = repository.MatchInsertOneRoomUser(ctx, tx, roomUserDTO)
 		if err != nil {
 			return err

--- a/src/features/v2ws/matchEventWebsocketUseCase.go
+++ b/src/features/v2ws/matchEventWebsocketUseCase.go
@@ -20,13 +20,13 @@ func CreateMatchRoomDTO(uID uint, count int, timer int) mysql.Rooms {
 	return result
 }
 
-func CreateMatchRoomUserDTO(uID uint, roomID int, playerState string) mysql.RoomUsers {
+func CreateMatchRoomUserDTO(uID uint, roomID int) mysql.RoomUsers {
 	result := mysql.RoomUsers{
 		UserID:         int(uID),
 		RoomID:         roomID,
 		Score:          0,
 		OwnedCardCount: 0,
-		PlayerState:    playerState,
+		PlayerState:    "play",
 		TurnNumber:     0,
 	}
 	return result

--- a/src/features/v2ws/model/entity/abnormalEntity.go
+++ b/src/features/v2ws/model/entity/abnormalEntity.go
@@ -2,5 +2,6 @@ package entity
 
 type WSAbnormalEntity struct {
 	RoomID         uint `json:"roomID omitempty"`
+	UserID         uint `json:"userID omitempty"`
 	AbnormalUserID uint `json:"abnormalUserID"`
 }

--- a/src/features/v2ws/model/entity/entity.go
+++ b/src/features/v2ws/model/entity/entity.go
@@ -125,6 +125,7 @@ type RoomUsers struct {
 	Cards          []mysql.UserBirdCards `gorm:"foreignKey:UserID,RoomID;references:UserID,RoomID"`
 	UserMissions   []mysql.UserMissions  `gorm:"foreignKey:UserID,RoomID;references:UserID,RoomID"`
 	UserItems      []mysql.UserItems     `gorm:"foreignKey:UserID,RoomID;references:UserID,RoomID"`
+	RoomUsers      mysql.RoomUsers       `gorm:"foreignKey:UserID,RoomID;references:UserID,RoomID"`
 }
 
 func (c *WSClient) Close() {

--- a/src/features/v2ws/playTogetherEventWebsocketHandler.go
+++ b/src/features/v2ws/playTogetherEventWebsocketHandler.go
@@ -98,7 +98,7 @@ func playTogether(c echo.Context) error {
 		}
 
 		// room_user 생성
-		roomUserDTO := CreatePlayTogetherRoomUserDTO(userID, int(roomID), "ready")
+		roomUserDTO := CreatePlayTogetherRoomUserDTO(userID, int(roomID))
 		err = repository.PlayTogetherInsertOneRoomUser(ctx, tx, roomUserDTO)
 		if err != nil {
 			return err

--- a/src/features/v2ws/playTogetherEventWebsocketUseCase.go
+++ b/src/features/v2ws/playTogetherEventWebsocketUseCase.go
@@ -31,13 +31,13 @@ func CreatePlayTogetherRoomDTO(uID uint, count int, timer int, password string) 
 	return result
 }
 
-func CreatePlayTogetherRoomUserDTO(uID uint, roomID int, playerState string) mysql.RoomUsers {
+func CreatePlayTogetherRoomUserDTO(uID uint, roomID int) mysql.RoomUsers {
 	result := mysql.RoomUsers{
 		UserID:         int(uID),
 		RoomID:         roomID,
 		Score:          0,
 		OwnedCardCount: 0,
-		PlayerState:    playerState,
+		PlayerState:    "play",
 		TurnNumber:     0,
 	}
 	return result

--- a/src/features/v2ws/repository/abnormalEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/abnormalEventWebsocketRepository.go
@@ -11,7 +11,7 @@ import (
 
 func AbnormalFindAllRoomUsers(ctx context.Context, tx *gorm.DB, roomID uint) ([]entity.RoomUsers, error) {
 	var roomUsers []entity.RoomUsers
-	if err := tx.Preload("User").Preload("Room").Preload("Cards", func(db *gorm.DB) *gorm.DB {
+	if err := tx.Preload("User").Preload("Room").Preload("RoomUsers").Preload("Cards", func(db *gorm.DB) *gorm.DB {
 		return db.Where("room_id = ?", roomID).Order("updated_at ASC")
 	}).Where("room_id = ?", roomID).Find(&roomUsers).Error; err != nil {
 		return nil, fmt.Errorf("room_users 조회 에러: %v", err.Error())
@@ -37,9 +37,9 @@ func AbnormalDeleteRoom(c context.Context, tx *gorm.DB, AbnormalEntity *entity.W
 	return nil
 }
 
-// 유저 상태 변경 (play -> wait)
-func AbnormalUpdateUsers(c context.Context, tx *gorm.DB, AbnormalEntity *entity.WSAbnormalEntity) error {
-	err := tx.Model(&mysql.Users{}).Where("room_id = ?", AbnormalEntity.RoomID).Update("state", "abnormal").Error
+// 룸 유저 상태 변경 (play -> wait)
+func AbnormalUpdateRoomUsers(c context.Context, tx *gorm.DB, AbnormalEntity *entity.WSAbnormalEntity) error {
+	err := tx.Model(&mysql.RoomUsers{}).Where("room_id = ? and user_id = ?", AbnormalEntity.RoomID, AbnormalEntity.UserID).Update("player_state", "disconnected").Error
 	if err != nil {
 		return fmt.Errorf("유저 상태 변경 실패 %v", err.Error())
 	}

--- a/src/features/v2ws/repository/repository.go
+++ b/src/features/v2ws/repository/repository.go
@@ -18,3 +18,11 @@ func FindAllOpenCards(c context.Context, roomID int) ([]int, error) {
 	}
 	return cards, nil
 }
+
+func ReconnectedUpdateRoomUser(c context.Context, roomID uint, userID uint) error {
+	err := mysql.GormMysqlDB.Model(&mysql.RoomUsers{}).Where("room_id = ? and user_id = ?", roomID, userID).Update("player_state", "play").Error
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/features/v2ws/repository/startEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/startEventWebsocketRepository.go
@@ -35,16 +35,16 @@ func StartDeleteCards(ctx context.Context, tx *gorm.DB, userID uint) error {
 }
 
 // 방장이 시작했는지 체크
-func StartCheckOwner(ctx context.Context, tx *gorm.DB, uID uint, roomID uint) (uint, error) {
+func StartCheckOwner(ctx context.Context, tx *gorm.DB, uID uint, roomID uint) error {
 	room := mysql.Rooms{}
 	err := tx.WithContext(ctx).Where("id = ?", roomID).First(&room).Error
 	if err != nil {
-		return 0, fmt.Errorf("방 정보를 찾을 수 없습니다. %v", err)
+		return fmt.Errorf("방 정보를 찾을 수 없습니다. %v", err)
 	}
 	if room.OwnerID != int(uID) {
-		return 0, fmt.Errorf("방장만 게임을 시작할 수 있습니다.")
+		return fmt.Errorf("방장만 게임을 시작할 수 있습니다.")
 	}
-	return uint(room.OwnerID), nil
+	return nil
 }
 
 // 방 유저들이 모두 준비했는지 체크

--- a/src/features/v2ws/startEventWebsocket.go
+++ b/src/features/v2ws/startEventWebsocket.go
@@ -33,27 +33,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 	preloadUsers := []entity.RoomUsers{}
 	err = mysql.Transaction(mysql.GormMysqlDB, func(tx *gorm.DB) error {
 		// 방장이 게임 시작 요청했는지 체크
-		ownerID, err := repository.StartCheckOwner(ctx, tx, uID, roomID)
-		if err != nil {
-			return err
-		}
-
-		// 방에 있는 유저들이 모두 레디 상태인지 확인
-		roomUsers, err := repository.StartCheckReady(ctx, tx, roomID)
-		if err != nil {
-			return err
-		}
-		if allReady := CheckRoomUsersReady(roomUsers, ownerID); !allReady {
-			return fmt.Errorf("모든 유저가 준비하지 않았습니다.")
-		}
-
-		// room user 데이터 변경 (대기 -> 플레이, 플레이 순번 랜덤으로 생성)
-		updatedRoomUsers, err := StartUpdateRoomUsers(roomUsers)
-		if err != nil {
-			return err
-		}
-		// room user 데이터 변경 (대기 -> 플레이)
-		err = repository.StartUpdateRoomUser(ctx, tx, updatedRoomUsers)
+		err := repository.StartCheckOwner(ctx, tx, uID, roomID)
 		if err != nil {
 			return err
 		}

--- a/src/features/v2ws/startEventWebsocketUseCase.go
+++ b/src/features/v2ws/startEventWebsocketUseCase.go
@@ -7,18 +7,6 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-func CheckRoomUsersReady(roomUsers []mysql.RoomUsers, ownerID uint) bool {
-	for _, ru := range roomUsers {
-		if ru.UserID == int(ownerID) {
-			continue
-		}
-		if ru.PlayerState != "ready" {
-			return false
-		}
-	}
-	return true
-}
-
 func StartUpdateRoomUsers(roomUsers []mysql.RoomUsers) ([]mysql.RoomUsers, error) {
 	visited := make(map[int]bool, len(roomUsers)+1)
 

--- a/src/features/v2ws/usecase.go
+++ b/src/features/v2ws/usecase.go
@@ -166,6 +166,12 @@ func CreateRoomInfoMSG(ctx context.Context, preloadUsers []entity.RoomUsers, pla
 			PlayerState:         "picking",
 			MissionSuccessCount: len(roomUser.UserMissions),
 		}
+		//유저 상태 변경 (비정상적인 경우)
+		if roomUser.RoomUsers.PlayerState == "disconnected" {
+			user.PlayerState = "disconnected"
+		}
+
+		// 아이템 정보 저장
 		for _, item := range roomUser.UserItems {
 			userItem := entity.Item{
 				ItemID:        uint(item.ItemID),
@@ -413,6 +419,10 @@ func restoreSession(ws *websocket.Conn, sessionID string, roomID uint, userID ui
 		// 핑/퐁 및 메시지 처리 시작
 		go HandlePingPong(entity.WSClients[sessionID])
 		go readMessages(ws, sessionID, roomID, userID)
+	}
+	err := repository.ReconnectedUpdateRoomUser(context.TODO(), roomID, userID)
+	if err != nil {
+		fmt.Println(err)
 	}
 }
 

--- a/src/features/v2ws/websocket.go
+++ b/src/features/v2ws/websocket.go
@@ -159,7 +159,7 @@ func HandlePingPong(wsClient *entity.WSClient) {
 				fmt.Printf("Error sending ping for session %s: %v\n", wsClient.SessionID, err)
 				wsClient.Closed = true
 				// Handle abnormal connection termination
-				AbnormalErrorHandling(wsClient.RoomID, wsClient.SessionID)
+				AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID, wsClient.SessionID)
 				return
 			}
 		}


### PR DESCRIPTION
This pull request includes several changes to improve the handling of user states and room user data across various websocket event handlers. The most important changes include adding user IDs to abnormal error handling, modifying the `CreateMatchRoomUserDTO` and `CreatePlayTogetherRoomUserDTO` functions, and updating room user states in different contexts.

Enhancements to user state handling:

* [`src/features/v2ws/abnormalEventWebsocket.go`](diffhunk://#diff-8d4e06632460e3846eab213ef37202f329c5439e9c97f436492af27d57a140a6L17-R30): Added `userID` parameter to `AbnormalErrorHandling` function and updated the call to `repository.AbnormalUpdateRoomUsers` to include `userID`.
* [`src/features/v2ws/model/entity/abnormalEntity.go`](diffhunk://#diff-d9a6958db79a126640cb874f589a9581db05987268fcace00677ac8db62433b2R5): Added `UserID` field to `WSAbnormalEntity` struct.
* [`src/features/v2ws/repository/abnormalEventWebsocketRepository.go`](diffhunk://#diff-c27f2bc027b8ac72c051154f9ca98b2def35cf1f76ecd95550ea96f1b311bb64L14-R14): Added `RoomUsers` preload to `AbnormalFindAllRoomUsers` and changed `AbnormalUpdateUsers` to `AbnormalUpdateRoomUsers` to update room user states. [[1]](diffhunk://#diff-c27f2bc027b8ac72c051154f9ca98b2def35cf1f76ecd95550ea96f1b311bb64L14-R14) [[2]](diffhunk://#diff-c27f2bc027b8ac72c051154f9ca98b2def35cf1f76ecd95550ea96f1b311bb64L40-R42)

Modifications to DTO creation functions:

* [`src/features/v2ws/matchEventWebsocketUseCase.go`](diffhunk://#diff-357ecf2c9cc1610d21cabe8b9c237418449c218ef81436ded03d3fa7453695c1L23-R29): Removed `playerState` parameter from `CreateMatchRoomUserDTO` and set `PlayerState` to "play" by default.
* [`src/features/v2ws/playTogetherEventWebsocketUseCase.go`](diffhunk://#diff-1bda4796748ec297beb4d11f3ab5a0920074dcfca72d65ce2a08508e47636a2fL34-R40): Removed `playerState` parameter from `CreatePlayTogetherRoomUserDTO` and set `PlayerState` to "play" by default.

Updating room user states:

* [`src/features/v2ws/usecase.go`](diffhunk://#diff-122266d3cc5139a49c21e7c8614a76653c41dc611c161445258862a598f6d68fR169-R174): Added logic to update room user state to "disconnected" in `CreateRoomInfoMSG` if the user was previously disconnected, and updated room user state to "play" on reconnection in `restoreSession`. [[1]](diffhunk://#diff-122266d3cc5139a49c21e7c8614a76653c41dc611c161445258862a598f6d68fR169-R174) [[2]](diffhunk://#diff-122266d3cc5139a49c21e7c8614a76653c41dc611c161445258862a598f6d68fR423-R426)
* [`src/features/v2ws/websocket.go`](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L162-R162): Updated `AbnormalErrorHandling` call in `HandlePingPong` to include `userID`.