### PR TITLE
{improvement} - 시작 이벤트시 메시지에서 세세션ID 삭제 \n #486

### DIFF
--- a/src/features/v2ws/startEventWebsocket.go
+++ b/src/features/v2ws/startEventWebsocket.go
@@ -95,6 +95,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		fmt.Println(err)
 	}
 	msg.Message = message
+	msg.SessionID = ""
 	// 유저 상태를 변경한다. (방에 참여)
 	if sessionIDs, ok := entity.RoomSessions[msg.RoomID]; ok {
 		// 에러 발생 시 이벤트 요청한 유저에게만 메시지를 전달한다.


### PR DESCRIPTION
This pull request includes a small change to the `src/features/v2ws/startEventWebsocket.go` file. The change initializes the `SessionID` field of the `WSMessage` struct to an empty string within the `StartEventWebsocket` function.

* [`src/features/v2ws/startEventWebsocket.go`](diffhunk://#diff-bf85675a88c433d2ffad7f96c2231b3ced4a703a7079dc36370f8fe4f17e74e0R98): Added initialization of `SessionID` to an empty string in the `StartEventWebsocket` function.