### PR TITLE
{improvement} - 게임이 강제 종료됐을 때 메시지 전송 \n #481

### DIFF
--- a/src/features/v2ws/abnormalEventWebsocket.go
+++ b/src/features/v2ws/abnormalEventWebsocket.go
@@ -41,9 +41,9 @@ func AbnormalErrorHandling(roomID, userID uint, sessionID string) {
 
 		// 에러 메시지 설정
 		roomInfoMsg.ErrorInfo = &entity.ErrorInfo{
-			Code: 500,
-			Msg:  "상대방이 게임 도중 나가서 강제 종료됐습니다.",
-			Type: _errors.ErrAbnormalExit,
+			Code: _errors.ErrCodeInternal,
+			Msg:  "상대방이 게임 도중 나가서 강제 중단되었습니다.",
+			Type: _errors.ErrGameTerminated,
 		}
 		return nil
 	})

--- a/src/features/v2ws/model/errors/error.go
+++ b/src/features/v2ws/model/errors/error.go
@@ -10,6 +10,7 @@ var (
 	ErrRoomFull              = "ERR_ROOM_FULL"
 	ErrBadRequest            = "ERR_BAD_REQUEST"
 	ErrAbnormalExit          = "ERR_ABNORMAL_EXIT"
+	ErrDisconnect            = "ERR_DISCONNECT"
 	ErrDBServer              = "ERR_DB_SERVER"
 	ErrInvalidToken          = "ERR_INVALID_TOKEN"
 	ErrRoomOut               = "ERR_ROOM_OUT"
@@ -29,7 +30,7 @@ var (
 	ErrUnauthorizedAction    = "ERR_UNAUTHORIZED_ACTION"
 	ErrFetchFailed           = "ERR_FETCH_FAILED"
 	ErrAlreadyGame           = "ERR_ALREADY_GAME"
-	// 에러 타입 정의
+	ErrGameTerminated        = "ERR_GAME_TERMINATED" // 게임 강제 중단
 )
 
 var (


### PR DESCRIPTION
This pull request introduces several changes to handle disconnections and abnormal exits more effectively in the WebSocket-based system. The changes include adding new error types, broadcasting messages to all users in a room when a disconnection occurs, and updating error handling messages.

### Error Handling Enhancements:
* Added new error types `ErrDisconnect` and `ErrGameTerminated` in `src/features/v2ws/model/errors/error.go` to better categorize different error scenarios. [[1]](diffhunk://#diff-71f57e7bad239ae09c29292b70e682b3982a18da53c6ede17a4fb35626871034R13) [[2]](diffhunk://#diff-71f57e7bad239ae09c29292b70e682b3982a18da53c6ede17a4fb35626871034L32-R33)
* Updated error handling messages to use the new error types in `src/features/v2ws/abnormalEventWebsocket.go`.

### Message Broadcasting:
* Introduced the `broadcastToRoom` function in `src/features/v2ws/abnormalEventUseCase.go` to send messages to all sessions in a room.
* Added the `broadcastDisconnectionMessage` function in `src/features/v2ws/websocket.go` to notify all users in a room about a user's disconnection.

### Abnormal Event Handling:
* Modified the `cleanupSession` function in `src/features/v2ws/abnormalEventUseCase.go` to broadcast an error message when a session is cleaned up due to a disconnection.
* Enhanced the `HandlePingPong` function in `src/features/v2ws/websocket.go` to notify users about disconnections during ping-pong checks.

### Import Adjustments:
* Added a new import for `_errors` in `src/features/v2ws/abnormalEventUseCase.go` to handle custom error types.