### PR TITLE
Fix/496/reconnect

### DIFF
--- a/src/features/v2ws/cancelMatchEventWebsocket.go
+++ b/src/features/v2ws/cancelMatchEventWebsocket.go
@@ -106,4 +106,6 @@ func CancelMatchEventWebsocket(msg *entity.WSMessage) {
 	}
 	msg.Message = message
 	sendMessageToClients(roomID, msg)
+
+	disconnectClient(uID, roomID)
 }

--- a/src/features/v2ws/model/entity/entity.go
+++ b/src/features/v2ws/model/entity/entity.go
@@ -26,6 +26,7 @@ type WSClient struct {
 	UserID    uint
 	Conn      *websocket.Conn
 	Closed    bool // 연결이 닫혔는지 여부를 추적하는 필드
+	Canceled  bool
 }
 
 type WSMessage struct {

--- a/src/features/v2ws/websocket.go
+++ b/src/features/v2ws/websocket.go
@@ -160,7 +160,8 @@ func HandlePingPong(wsClient *entity.WSClient) {
 				// Notify all users in the same room about the disconnection
 
 				// wsClient.Closed = true
-				if !wsClient.Closed {
+				if !wsClient.Canceled {
+					fmt.Println("여기 들어와야 되는데 안들어오나??")
 					AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID, wsClient.SessionID)
 					return
 				}
@@ -280,6 +281,7 @@ func broadcastDisconnectionMessage(wsClient *entity.WSClient) {
 }
 
 func disconnectClient(userID, roomID uint) {
+	fmt.Println("연결 끊는다. ", userID, roomID)
 	// RoomID에 연결된 모든 세션을 검색
 	if sessionIDs, ok := entity.RoomSessions[roomID]; ok {
 		for _, sessionID := range sessionIDs {
@@ -288,6 +290,7 @@ func disconnectClient(userID, roomID uint) {
 				// 클라이언트 연결 종료
 				client.Conn.Close()
 				client.Closed = true
+				client.Canceled = true
 
 				// 세션 및 클라이언트 데이터 정리
 				delete(entity.WSClients, sessionID)

--- a/src/features/v2ws/websocket.go
+++ b/src/features/v2ws/websocket.go
@@ -158,10 +158,14 @@ func HandlePingPong(wsClient *entity.WSClient) {
 			if err := ws.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(WriteWait)); err != nil {
 				fmt.Printf("Error sending ping for session %s: %v\n", wsClient.SessionID, err)
 				// Notify all users in the same room about the disconnection
-				
-				wsClient.Closed = true
+
+				// wsClient.Closed = true
+				if !wsClient.Closed {
+					AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID, wsClient.SessionID)
+					return
+				}
 				// Handle abnormal connection termination
-				AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID, wsClient.SessionID)
+				// AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID, wsClient.SessionID)
 				return
 			}
 		}
@@ -272,5 +276,28 @@ func broadcastDisconnectionMessage(wsClient *entity.WSClient) {
 				}
 			}
 		}
+	}
+}
+
+func disconnectClient(userID, roomID uint) {
+	// RoomID에 연결된 모든 세션을 검색
+	if sessionIDs, ok := entity.RoomSessions[roomID]; ok {
+		for _, sessionID := range sessionIDs {
+			// 특정 userID를 가진 클라이언트를 찾는다.
+			if client, exists := entity.WSClients[sessionID]; exists && client.UserID == userID {
+				// 클라이언트 연결 종료
+				client.Conn.Close()
+				client.Closed = true
+
+				// 세션 및 클라이언트 데이터 정리
+				delete(entity.WSClients, sessionID)
+				removeSessionFromRoom(roomID, sessionID)
+
+				fmt.Printf("User %d disconnected from room %d\n", userID, roomID)
+				break
+			}
+		}
+	} else {
+		fmt.Printf("Room %d does not exist or has no active sessions\n", roomID)
 	}
 }


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of WebSocket connections, particularly focusing on the disconnection process. The most important changes include adding a new function to disconnect clients, modifying the `WSClient` struct to include a `Canceled` field, and adjusting the logic in the `HandlePingPong` function to handle abnormal disconnections more effectively.

Enhancements to WebSocket disconnection handling:

* [`src/features/v2ws/cancelMatchEventWebsocket.go`](diffhunk://#diff-3c9a3aad502e01e34bd5e448bb25914c3b457884e5acfb2e58b72f209038ecfcR109-R110): Added a call to `disconnectClient` to ensure clients are properly disconnected when a match event is canceled.
* [`src/features/v2ws/model/entity/entity.go`](diffhunk://#diff-557b9d484d69fb558b082811c2cd15cb335003791a9d61b5d90cbb6f457f8538R29): Added a `Canceled` field to the `WSClient` struct to track whether a client has been intentionally disconnected.
* [`src/features/v2ws/websocket.go`](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L162-R171): Modified the `HandlePingPong` function to check the `Canceled` field before handling abnormal disconnections, and added debug print statements for better traceability.
* [`src/features/v2ws/websocket.go`](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9R282-R306): Added a new `disconnectClient` function to handle the disconnection process, including closing the connection, updating client status, and cleaning up session data.