### PR TITLE
Fix/496/reconnect

### DIFF
--- a/src/features/v2ws/abnormalEventUseCase.go
+++ b/src/features/v2ws/abnormalEventUseCase.go
@@ -118,7 +118,6 @@ func broadcastToRoom(roomID uint, msg entity.WSMessage) {
 			if client, exists := entity.WSClients[sessionID]; exists {
 				err := client.Conn.WriteJSON(msg)
 				if err != nil {
-					fmt.Printf("Failed to send message to session %s: %v\n", sessionID, err)
 					client.Closed = true
 				}
 			}

--- a/src/features/v2ws/abnormalEventUseCase.go
+++ b/src/features/v2ws/abnormalEventUseCase.go
@@ -67,12 +67,21 @@ func cleanupSession(roomID uint, sessionID string, preloadUsers []entity.RoomUse
 		if err := repository.AbnormalDeleteRoom(ctx, tx, &abnormalEntity); err != nil {
 			return fmt.Errorf("Failed to delete room: %s", err.Msg)
 		}
+		// 방 유저 정보 삭제
+		if err := repository.AbnormalDeleteRoomUsers(ctx, tx, &abnormalEntity); err != nil {
+			return fmt.Errorf("Failed to delete room users: %s", err.Msg)
+		}
+
 		return nil
 	})
-
 	// 에러 처리
 	if err != nil {
 		fmt.Printf("Cleanup error: %v\n", err)
+	}
+	// 레디스 세션값 삭제
+	newErr := repository.RedisSessionDelete(ctx, sessionID)
+	if newErr != nil {
+		fmt.Printf("Failed to delete session: %v\n", newErr.Msg)
 	}
 
 	// 클라이언트 연결 종료 및 제거

--- a/src/features/v2ws/abnormalEventWebsocket.go
+++ b/src/features/v2ws/abnormalEventWebsocket.go
@@ -14,7 +14,7 @@ import (
 
 var reconnectTimers sync.Map // 재접속 타이머를 관리하는 맵
 
-// 비정상적인 에러를 처리하는 함수
+// 비정상 연결로 인해 게임 강제 중단
 func AbnormalErrorHandling(roomID, userID uint, sessionID string) {
 	ctx := context.TODO()
 	roomInfoMsg := entity.RoomInfo{}

--- a/src/features/v2ws/joinPlayEventWebsocketHandler.go
+++ b/src/features/v2ws/joinPlayEventWebsocketHandler.go
@@ -67,6 +67,7 @@ func joinPlay(c echo.Context) error {
 		roomID, _ := repository.JoinRedisSessionGet(context.Background(), req.SessionID)
 		if roomID != 0 {
 			// 기존 연결 복구
+			fmt.Println("재접속 복구를 시도한다. ", roomID, userID)
 			restoreSession(ws, req.SessionID, roomID, userID)
 			// 연결한 유저에게 메시지 정보를 전달해야 된다.
 			return nil

--- a/src/features/v2ws/matchEventWebsocketHandler.go
+++ b/src/features/v2ws/matchEventWebsocketHandler.go
@@ -47,7 +47,10 @@ func match(c echo.Context) error {
 		roomID, _ := repository.MatchRedisSessionGet(context.Background(), req.SessionID)
 		if roomID != 0 {
 			// 기존 연결 복구
-			fmt.Println("재접속 복구를 시도한다. ", roomID, userID, req.SessionID)
+			if client, exists := entity.WSClients[req.SessionID]; exists {
+				closeAndRemoveClient(client, req.SessionID, roomID)
+			}
+
 			restoreSession(ws, req.SessionID, roomID, userID)
 			// 연결한 유저에게 메시지 정보를 전달해야 된다.
 			return nil

--- a/src/features/v2ws/matchEventWebsocketHandler.go
+++ b/src/features/v2ws/matchEventWebsocketHandler.go
@@ -47,6 +47,7 @@ func match(c echo.Context) error {
 		roomID, _ := repository.MatchRedisSessionGet(context.Background(), req.SessionID)
 		if roomID != 0 {
 			// 기존 연결 복구
+			fmt.Println("재접속 복구를 시도한다. ", roomID, userID, req.SessionID)
 			restoreSession(ws, req.SessionID, roomID, userID)
 			// 연결한 유저에게 메시지 정보를 전달해야 된다.
 			return nil
@@ -129,6 +130,7 @@ func match(c echo.Context) error {
 
 	// 세션 ID 생성
 	sessionID := generateSessionID()
+
 	// 세션 ID 저장
 	newErr = repository.MatchRedisSessionSet(ctx, sessionID, roomID)
 	if newErr != nil {

--- a/src/features/v2ws/model/entity/entity.go
+++ b/src/features/v2ws/model/entity/entity.go
@@ -131,6 +131,7 @@ type RoomUsers struct {
 
 func (c *WSClient) Close() {
 	c.Closed = true
+	c.Canceled = true
 	c.Conn.Close()
 }
 

--- a/src/features/v2ws/model/entity/entity.go
+++ b/src/features/v2ws/model/entity/entity.go
@@ -26,7 +26,6 @@ type WSClient struct {
 	UserID    uint
 	Conn      *websocket.Conn
 	Closed    bool // 연결이 닫혔는지 여부를 추적하는 필드
-	Canceled  bool
 }
 
 type WSMessage struct {
@@ -131,7 +130,6 @@ type RoomUsers struct {
 
 func (c *WSClient) Close() {
 	c.Closed = true
-	c.Canceled = true
 	c.Conn.Close()
 }
 

--- a/src/features/v2ws/model/errors/error.go
+++ b/src/features/v2ws/model/errors/error.go
@@ -19,6 +19,7 @@ var (
 	ErrRoomUsersNotFound     = "ERR_ROOM_USERS_NOT_FOUND"
 	ErrDeleteCardFailed      = "ERR_DELETE_CARD_FAILED"
 	ErrDeleteRoomFailed      = "ERR_DELETE_ROOM_FAILED"
+	ErrDeleteRoomUserFailed  = "ERR_DELETE_ROOM_USER_FAILED"
 	ErrUpdateUserStateFailed = "ERR_UPDATE_USER_STATE_FAILED"
 	ErrUserNotFound          = "ERR_USER_NOT_FOUND"
 	ErrRoomNotFound          = "ERR_ROOM_NOT_FOUND"

--- a/src/features/v2ws/repository/abnormalEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/abnormalEventWebsocketRepository.go
@@ -22,12 +22,12 @@ func AbnormalFindAllRoomUsers(ctx context.Context, tx *gorm.DB, roomID uint) ([]
 
 // 카드 정보 모두 삭제
 func AbnormalDeleteAllCards(ctx context.Context, tx *gorm.DB, AbnormalEntity *entity.WSAbnormalEntity) *entity.ErrorInfo {
-	err := tx.Model(&mysql.Cards{}).Where("room_id = ?", AbnormalEntity.RoomID).Delete(&mysql.Cards{}).Error
+	err := tx.Model(&mysql.UserBirdCards{}).Where("room_id = ?", AbnormalEntity.RoomID).Delete(&mysql.UserBirdCards{}).Error
 	if err != nil {
 		return &entity.ErrorInfo{
 			Code: _errors.ErrCodeInternal,
 			Msg:  fmt.Sprintf("카드 삭제 실패: %v", err),
-			Type:_errors. ErrDeleteCardFailed,
+			Type: _errors.ErrDeleteCardFailed,
 		}
 	}
 	return nil
@@ -41,6 +41,19 @@ func AbnormalDeleteRoom(ctx context.Context, tx *gorm.DB, AbnormalEntity *entity
 			Code: _errors.ErrCodeInternal,
 			Msg:  fmt.Sprintf("방 삭제 실패: %v", err),
 			Type: _errors.ErrDeleteRoomFailed,
+		}
+	}
+	return nil
+}
+
+// 방 유저 정보 삭제
+func AbnormalDeleteRoomUsers(ctx context.Context, tx *gorm.DB, AbnormalEntity *entity.WSAbnormalEntity) *entity.ErrorInfo {
+	err := tx.Model(&mysql.RoomUsers{}).Where("room_id = ?", AbnormalEntity.RoomID).Delete(&mysql.RoomUsers{}).Error
+	if err != nil {
+		return &entity.ErrorInfo{
+			Code: _errors.ErrCodeInternal,
+			Msg:  fmt.Sprintf("방 유저 삭제 실패: %v", err),
+			Type: _errors.ErrDeleteRoomUserFailed,
 		}
 	}
 	return nil

--- a/src/features/v2ws/repository/matchEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/matchEventWebsocketRepository.go
@@ -250,6 +250,7 @@ func MatchRedisSessionSet(ctx context.Context, sessionID string, roomID uint) *e
 	return nil
 }
 
+
 func MatchDeleteRooms(ctx context.Context, uID uint) *entity.ErrorInfo {
 	result := mysql.GormMysqlDB.WithContext(ctx).Where("owner_id = ?", uID).Delete(&mysql.Rooms{})
 	if result.Error != nil {

--- a/src/features/v2ws/repository/repository.go
+++ b/src/features/v2ws/repository/repository.go
@@ -2,7 +2,11 @@ package repository
 
 import (
 	"context"
+	"fmt"
+	"main/features/v2ws/model/entity"
+	_errors "main/features/v2ws/model/errors"
 	"main/utils/db/mysql"
+	_redis "main/utils/db/redis"
 
 	"gorm.io/gorm"
 )
@@ -24,5 +28,20 @@ func ReconnectedUpdateRoomUser(c context.Context, roomID uint, userID uint) erro
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func RedisSessionDelete(ctx context.Context, sessionID string) *entity.ErrorInfo {
+	redisKey := fmt.Sprintf("abnormal_session:%s", sessionID)
+	// Redis에서 키 삭제
+	err := _redis.Client.Del(ctx, redisKey).Err()
+	if err != nil {
+		return &entity.ErrorInfo{
+			Code: _errors.ErrCodeInternal,
+			Msg:  fmt.Sprintf("세션 삭제 실패: %v", err.Error()),
+			Type: _errors.ErrInternalServer,
+		}
+	}
+
 	return nil
 }

--- a/src/features/v2ws/usecase.go
+++ b/src/features/v2ws/usecase.go
@@ -377,21 +377,31 @@ func restoreSession(ws *websocket.Conn, sessionID string, roomID uint, userID ui
 		reconnectTimers.Delete(sessionID)
 		fmt.Printf("Reconnection successful for session %s in room %d. Timer canceled.\n", sessionID, roomID)
 	}
+	fmt.Println("test ", sessionID)
+	fmt.Println(len(entity.WSClients))
+	fmt.Println(entity.WSClients)
+	fmt.Println(entity.WSClients[sessionID])
 	if client, ok := entity.WSClients[sessionID]; ok {
 		fmt.Println("바로 연결하면 여기 들어올거 같다.")
-		// 기존 연결 닫기
+		// client.Conn.Close()
 		client.Closed = true
-		client.Conn.Close()
+		client.Canceled = true
 
 		// 새로운 연결로 갱신
-		client.Conn = ws
-		client.Closed = false
-		entity.WSClients[sessionID] = client
+		newClient := &entity.WSClient{
+			SessionID: sessionID,
+			RoomID:    roomID,
+			UserID:    userID,
+			Conn:      ws,
+			Closed:    false,
+			Canceled:  false,
+		}
+		entity.WSClients[sessionID] = newClient
 
 		fmt.Printf("User %d reconnected to Room %d with Session %s.\n", userID, roomID, sessionID)
 
 		// 핑/퐁 핸들링 재시작
-		go HandlePingPong(client)
+		go HandlePingPong(newClient)
 
 		// 메시지 처리 루프 시작
 		go readMessages(ws, sessionID, roomID, userID)
@@ -428,10 +438,12 @@ func registerNewSession(ws *websocket.Conn, sessionID string, roomID uint, userI
 		Closed:    false,
 	}
 	entity.WSClients[sessionID] = wsClient
+	fmt.Println("새로운 세션 등록", entity.WSClients[sessionID])
+	fmt.Println(entity.WSClients[sessionID], sessionID)
 
 	// 방에 세션 추가
 	entity.RoomSessions[roomID] = append(entity.RoomSessions[roomID], sessionID)
-
+	fmt.Println(len(entity.RoomSessions[roomID]))
 	// 핑/퐁 핸들링 시작
 	go HandlePingPong(wsClient)
 
@@ -447,16 +459,10 @@ func readMessages(ws *websocket.Conn, sessionID string, roomID uint, userID uint
 	defer func() {
 		// 연결 종료 시 세션 정리
 		client.Closed = true
-		ws.Close()
-		delete(entity.WSClients, sessionID)
-		removeSessionFromRoom(roomID, sessionID)
+		// ws.Close()
+		// delete(entity.WSClients, sessionID)
+		// removeSessionFromRoom(roomID, sessionID)
 		fmt.Println("Session", sessionID, "closed. Read loop stopped.")
-
-		// 방 삭제 여부 확인
-		if len(entity.RoomSessions[roomID]) == 0 {
-			delete(entity.RoomSessions, roomID)
-			log.Printf("Room %d deleted as it has no active sessions.", roomID)
-		}
 	}()
 
 	for {
@@ -496,9 +502,9 @@ func sendMessageToClients(roomID uint, msg *entity.WSMessage) {
 			if client, exists := entity.WSClients[sessionID]; exists {
 				if err := client.Conn.WriteJSON(msg); err != nil {
 					fmt.Printf("Failed to send message to session %s: %v\n", sessionID, err)
-					client.Close()
-					delete(entity.WSClients, sessionID)
-					removeSessionFromRoom(roomID, sessionID)
+					// client.Close()
+					// delete(entity.WSClients, sessionID)
+					// removeSessionFromRoom(roomID, sessionID)
 				}
 			}
 		}


### PR DESCRIPTION
This pull request includes several changes to improve error handling, session management, and logging in the WebSocket feature. The most important changes include adding functions to delete room users and Redis sessions, modifying the ping/pong handling, and updating the session restoration process.

### Improvements to error handling and session management:

* Added a function to delete room users in `src/features/v2ws/repository/abnormalEventWebsocketRepository.go` and updated `cleanupSession` to call this function. (`[[1]](diffhunk://#diff-8e34c975e6afd874c24641283d07aff79980c335495c58df92abf5f425858d95R70-R85)`, `[[2]](diffhunk://#diff-c27f2bc027b8ac72c051154f9ca98b2def35cf1f76ecd95550ea96f1b311bb64R49-R61)`)
* Added a function to delete Redis sessions in `src/features/v2ws/repository/repository.go` and updated `cleanupSession` and `disconnectClient` to call this function. (`[[1]](diffhunk://#diff-8e34c975e6afd874c24641283d07aff79980c335495c58df92abf5f425858d95R70-R85)`, `[[2]](diffhunk://#diff-7aef7f2d6d85213c90a88d460ec3363a4f72dd6e91ec332b94411b20c7a8ad99R33-R47)`, `[[3]](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L293-R251)`)
* Removed the `Canceled` field from the `WSClient` struct in `src/features/v2ws/model/entity/entity.go`. (`[src/features/v2ws/model/entity/entity.goL29](diffhunk://#diff-557b9d484d69fb558b082811c2cd15cb335003791a9d61b5d90cbb6f457f8538L29)`)

### Modifications to ping/pong handling:

* Updated the `HandlePingPong` function to handle closed connections more effectively in `src/features/v2ws/websocket.go`. (`[src/features/v2ws/websocket.goL159-L169](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L159-L169)`)
* Adjusted the `WriteWait` and `PongWait` constants to reduce the ping/pong interval in `src/features/v2ws/websocket.go`. (`[src/features/v2ws/websocket.goL26-R28](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L26-R28)`)

### Session restoration updates:

* Refactored the `restoreSession` function to generate a new session ID and register a new session in `src/features/v2ws/usecase.go`. (`[src/features/v2ws/usecase.goL380-R389](diffhunk://#diff-122266d3cc5139a49c21e7c8614a76653c41dc611c161445258862a598f6d68fL380-R389)`)
* Updated the `broadcastToRoom` function to remove redundant error logging in `src/features/v2ws/abnormalEventUseCase.go`. (`[src/features/v2ws/abnormalEventUseCase.goL112](diffhunk://#diff-8e34c975e6afd874c24641283d07aff79980c335495c58df92abf5f425858d95L112)`)