### PR TITLE
{improvement} - log.fatalf 제거 완료 \n #504

### DIFF
--- a/src/features/v2ws/abnormalEventWebsocket.go
+++ b/src/features/v2ws/abnormalEventWebsocket.go
@@ -15,7 +15,7 @@ import (
 var reconnectTimers sync.Map // 재접속 타이머를 관리하는 맵
 
 // 비정상 연결로 인해 게임 강제 중단
-func AbnormalErrorHandling(roomID, userID uint, sessionID string) {
+func AbnormalSendErrorMessage(roomID, userID uint, sessionID string) {
 	ctx := context.TODO()
 	roomInfoMsg := entity.RoomInfo{}
 	preloadUsers := []entity.RoomUsers{}

--- a/src/features/v2ws/cancelMatchEventWebsocket.go
+++ b/src/features/v2ws/cancelMatchEventWebsocket.go
@@ -35,7 +35,7 @@ func CancelMatchEventWebsocket(msg *entity.WSMessage) {
 		err := repository.CancelMatchDeleteOneRoomUser(ctx, tx, roomID, uID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -43,7 +43,7 @@ func CancelMatchEventWebsocket(msg *entity.WSMessage) {
 		err = repository.CancelMatchFindOneAndUpdateUser(ctx, tx, uID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -51,7 +51,7 @@ func CancelMatchEventWebsocket(msg *entity.WSMessage) {
 		roomDTO, err := repository.CancelMatchFindOneAndUpdateRoom(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		//
@@ -61,21 +61,21 @@ func CancelMatchEventWebsocket(msg *entity.WSMessage) {
 			roomUserID, err := repository.CancelMatchFindOneRoomUser(ctx, tx, roomID)
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 			//해당 유저ID를 방장으로 변경한다.
 			err = repository.CancelMatchUpdateRoomOwner(ctx, tx, roomID, roomUserID)
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 		}
 		preloadUsers, err = repository.CancelMatchFindAllRoomUsers(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		return nil

--- a/src/features/v2ws/closeEventWebsocket.go
+++ b/src/features/v2ws/closeEventWebsocket.go
@@ -29,21 +29,21 @@ func CloseEventWebsocket(msg *entity.WSMessage) {
 		err := repository.CloseFindOneAndDeleteRoomUser(ctx, tx, uID, req.RoomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		// Rooms 현재 인원수를 -1한다.
 		roomDTO, err := repository.CloseFindOneAndUpdateRoom(ctx, tx, req.RoomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		// user에 rooms_id를 1로 바꾸고 state를 wait으로 변경한다.
 		err = repository.CloseFindOneAndUpdateUser(ctx, tx, uID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -52,7 +52,7 @@ func CloseEventWebsocket(msg *entity.WSMessage) {
 			err = repository.CloseFindOneAndDeleteRoom(ctx, tx, req.RoomID)
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 
@@ -63,13 +63,13 @@ func CloseEventWebsocket(msg *entity.WSMessage) {
 			roomUserDTO, err := repository.CloseFindOneRoomUser(ctx, tx, req.RoomID)
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 			userDTO, err := repository.CloseFindOneUser(ctx, tx, uint(roomUserDTO.UserID))
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 
@@ -80,14 +80,14 @@ func CloseEventWebsocket(msg *entity.WSMessage) {
 			err = repository.CloseChangeRoomOnwer(ctx, tx, req.RoomID, userDTO.ID)
 			if err != nil {
 				roomInfoMsg.ErrorInfo = err
-				ErrorHandling(msg, &roomInfoMsg)
+				SendErrorMessage(msg, &roomInfoMsg)
 				return fmt.Errorf("%s", err.Msg)
 			}
 		}
 		preloadUsers, err = repository.CloseFindAllRoomUsers(ctx, tx, req.RoomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		return nil

--- a/src/features/v2ws/gameOverEventWebsocket.go
+++ b/src/features/v2ws/gameOverEventWebsocket.go
@@ -30,13 +30,13 @@ func GameOverEventWebsocket(msg *entity.WSMessage) {
 		err := repository.GameOverUpdateRoomUsers(ctx, tx, &GameOverEntity)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		preloadUsers, err = repository.GameOverFindAllRoomUsers(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 

--- a/src/features/v2ws/itemChangeEventWebsocket.go
+++ b/src/features/v2ws/itemChangeEventWebsocket.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"main/features/v2ws/model/entity"
+	_errors "main/features/v2ws/model/errors"
 	"main/features/v2ws/model/request"
 	"main/features/v2ws/repository"
 	"main/utils"
@@ -22,13 +22,17 @@ func ItemChangeEventWebsocket(msg *entity.WSMessage) {
 	// 복호화 후 JSON 언마샬링
 	decryptedMessage, err := utils.DecryptAES(msg.Message)
 	if err != nil {
-		log.Fatalf("AES 복호화 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrCryptoFailed, "AES 복호화 에러")
+		msg.Message = errMsg
+		sendMessageToClient(roomID, msg)
 	}
 	//string to struct
 	req := request.ReqWSItemChange{}
 	err = json.Unmarshal([]byte(decryptedMessage), &req)
 	if err != nil {
-		log.Fatalf("JSON 언마샬링 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrUnmarshalFailed, "JSON 언마샬링 에러")
+		msg.Message = errMsg
+		sendMessageToClient(roomID, msg)
 	}
 
 	ItemChangeEntity := entity.WSItemChangeEntity{
@@ -44,7 +48,7 @@ func ItemChangeEventWebsocket(msg *entity.WSMessage) {
 	newErr := repository.ItemChangeCheck(ctx, ItemChangeEntity)
 	if newErr != nil {
 		roomInfoMsg.ErrorInfo = newErr
-		ErrorHandling(msg, &roomInfoMsg)
+		SendErrorMessage(msg, &roomInfoMsg)
 		return
 	}
 
@@ -53,14 +57,14 @@ func ItemChangeEventWebsocket(msg *entity.WSMessage) {
 		err := repository.ItemChange(ctx, tx, ItemChangeEntity)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		// 아이템 사용 횟수를 -1 감소한다.
 		err = repository.ItemChangeConsumeUserItems(ctx, tx, ItemChangeEntity)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 

--- a/src/features/v2ws/model/errors/error.go
+++ b/src/features/v2ws/model/errors/error.go
@@ -10,6 +10,8 @@ var (
 	ErrRoomFull              = "ERR_ROOM_FULL"
 	ErrBadRequest            = "ERR_BAD_REQUEST"
 	ErrAbnormalExit          = "ERR_ABNORMAL_EXIT"
+	ErrCryptoFailed          = "ERR_CRYPTO_FAILED"
+	ErrUnmarshalFailed       = "ERR_UNMARSHAL_FAILED"
 	ErrDisconnect            = "ERR_DISCONNECT"
 	ErrDBServer              = "ERR_DB_SERVER"
 	ErrInvalidToken          = "ERR_INVALID_TOKEN"

--- a/src/features/v2ws/playTogetherEventWebsocket.go
+++ b/src/features/v2ws/playTogetherEventWebsocket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"main/features/v2ws/model/entity"
 	_errors "main/features/v2ws/model/errors"
 	"main/features/v2ws/model/request"
@@ -20,13 +19,17 @@ func PlayTogetherEventWebsocket(msg *entity.WSMessage) {
 	uID := msg.UserID
 	decryptedMessage, err := utils.DecryptAES(msg.Message)
 	if err != nil {
-		log.Fatalf("AES 복호화 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrCryptoFailed, "AES 복호화 에러")
+		msg.Message = errMsg
+		sendMessageToClient(msg.RoomID, msg)
 	}
 	//string to struct
 	req := request.ReqWSPlayTogetherEvent{}
 	err = json.Unmarshal([]byte(decryptedMessage), &req)
 	if err != nil {
-		log.Fatalf("JSON 언마샬링 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrUnmarshalFailed, "JSON 언마샬링 에러")
+		msg.Message = errMsg
+		sendMessageToClient(msg.RoomID, msg)
 	}
 
 	//비즈니스 로직
@@ -35,7 +38,7 @@ func PlayTogetherEventWebsocket(msg *entity.WSMessage) {
 	roomID, newErr := repository.PlayTogetherFindOneRoomUsers(ctx, uID)
 	if newErr != nil {
 		roomInfoMsg.ErrorInfo = newErr
-		ErrorHandling(msg, &roomInfoMsg)
+		SendErrorMessage(msg, &roomInfoMsg)
 		return
 	}
 	err = mysql.Transaction(mysql.GormMysqlDB, func(tx *gorm.DB) error {
@@ -43,7 +46,7 @@ func PlayTogetherEventWebsocket(msg *entity.WSMessage) {
 		err := repository.PlayTogetherFindOneAndUpdateRoom(ctx, tx, roomID, uint(req.Count), uint(req.Timer))
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -51,20 +54,20 @@ func PlayTogetherEventWebsocket(msg *entity.WSMessage) {
 		err = repository.PlayTogetherFindOneAndUpdateUser(ctx, tx, uID, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		// 미션 3개를 생성한다.
 		err = repository.PlayTogetherCreateMissions(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		preloadUsers, err = repository.PlayTogetherFindAllRoomUsers(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		return nil

--- a/src/features/v2ws/startEventWebsocket.go
+++ b/src/features/v2ws/startEventWebsocket.go
@@ -24,7 +24,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 	roomState, newErr := repository.StartCheckRoomState(ctx, roomID)
 	if newErr != nil {
 		roomInfoMsg.ErrorInfo = newErr
-		ErrorHandling(msg, &roomInfoMsg)
+		SendErrorMessage(msg, &roomInfoMsg)
 		return
 	}
 	if roomState != "wait" {
@@ -33,7 +33,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 			Msg:  "게임이 시작되었습니다.",
 			Type: _errors.ErrAlreadyGame,
 		}
-		ErrorHandling(msg, &roomInfoMsg)
+		SendErrorMessage(msg, &roomInfoMsg)
 		return
 	}
 
@@ -42,7 +42,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		err := repository.StartCheckOwner(ctx, tx, uID, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -51,7 +51,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		err = repository.StartUpdateRoom(ctx, tx, roomID, roomUpdateData)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -59,7 +59,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		err = repository.StartDiffCoin(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
@@ -67,13 +67,13 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		err = repository.StartDeleteCards(ctx, tx, uID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		birdCards, err := repository.StartBirdCard(ctx, tx)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		// 카드를 생성한다.
@@ -81,7 +81,7 @@ func StartEventWebsocket(msg *entity.WSMessage) {
 		err = repository.StartCreateCards(ctx, tx, cards)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 

--- a/src/features/v2ws/timeOutDiscardEventWebsocket.go
+++ b/src/features/v2ws/timeOutDiscardEventWebsocket.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"main/features/v2ws/model/entity"
+	_errors "main/features/v2ws/model/errors"
 	"main/features/v2ws/model/request"
 	"main/features/v2ws/repository"
 	"main/utils"
@@ -21,13 +21,17 @@ func TimeOutDiscardCardsEventWebsocket(msg *entity.WSMessage) {
 	roomID := msg.RoomID
 	decryptedMessage, err := utils.DecryptAES(msg.Message)
 	if err != nil {
-		log.Fatalf("AES 복호화 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrCryptoFailed, "AES 복호화 에러")
+		msg.Message = errMsg
+		sendMessageToClient(roomID, msg)
 	}
 	//string to struct
 	req := request.ReqWSTimeOutDiscardCards{}
 	err = json.Unmarshal([]byte(decryptedMessage), &req)
 	if err != nil {
-		log.Fatalf("JSON 언마샬링 에러: %s", err)
+		errMsg := CreateErrorMessage(_errors.ErrCodeBadRequest, _errors.ErrUnmarshalFailed, "JSON 언마샬링 에러")
+		msg.Message = errMsg
+		sendMessageToClient(roomID, msg)
 	}
 	TimeOutDiscardCardsEntity := entity.WSTimeOutDiscardCardsEntity{
 		RoomID: roomID,
@@ -44,20 +48,20 @@ func TimeOutDiscardCardsEventWebsocket(msg *entity.WSMessage) {
 		err := repository.TimeOutDiscardCardsUpdateCardState(ctx, tx, &TimeOutDiscardCardsEntity)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 
 		doraDTO, err = repository.TimeOutDiscardCardsFindOneDora(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		preloadUsers, err = repository.TimeOutDiscardCardsFindAllRoomUsers(ctx, tx, roomID)
 		if err != nil {
 			roomInfoMsg.ErrorInfo = err
-			ErrorHandling(msg, &roomInfoMsg)
+			SendErrorMessage(msg, &roomInfoMsg)
 			return fmt.Errorf("%s", err.Msg)
 		}
 		return nil

--- a/src/features/ws/abnormalEventWebsocket.go
+++ b/src/features/ws/abnormalEventWebsocket.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func AbnormalErrorHandling(roomID, userID uint) {
+func AbnormalSendErrorMessage(roomID, userID uint) {
 	// 비정상적인 에러 발생했으므로 비정상적 에러 처리하는 로직 실행
 
 	//business logic

--- a/src/features/ws/websocket.go
+++ b/src/features/ws/websocket.go
@@ -96,7 +96,7 @@ func HandlePingPong(wsClient *entity.WSClient) {
 			}
 			if err := ws.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(WriteWait)); err != nil {
 				fmt.Println("Error sending ping:", err)
-				AbnormalErrorHandling(wsClient.RoomID, wsClient.UserID)
+				AbnormalSendErrorMessage(wsClient.RoomID, wsClient.UserID)
 				return
 			}
 


### PR DESCRIPTION
This pull request focuses on refactoring error handling across multiple websocket event files. The primary change involves replacing the `ErrorHandling` function with a new `SendErrorMessage` function. Additionally, some logging statements have been removed and replaced with error message handling.

Error Handling Refactor:

* [`src/features/v2ws/abnormalEventWebsocket.go`](diffhunk://#diff-8d4e06632460e3846eab213ef37202f329c5439e9c97f436492af27d57a140a6L18-R18): Renamed `AbnormalErrorHandling` function to `AbnormalSendErrorMessage` and updated its implementation.
* [`src/features/v2ws/cancelMatchEventWebsocket.go`](diffhunk://#diff-3c9a3aad502e01e34bd5e448bb25914c3b457884e5acfb2e58b72f209038ecfcL38-R54): Replaced `ErrorHandling` with `SendErrorMessage` in the `CancelMatchEventWebsocket` function. [[1]](diffhunk://#diff-3c9a3aad502e01e34bd5e448bb25914c3b457884e5acfb2e58b72f209038ecfcL38-R54) [[2]](diffhunk://#diff-3c9a3aad502e01e34bd5e448bb25914c3b457884e5acfb2e58b72f209038ecfcL64-R78)
* [`src/features/v2ws/closeEventWebsocket.go`](diffhunk://#diff-7df8a2388e8a257f69ef2bd4a9adfc7a9b25a20f8f71907650cc7c7ddc72463aL32-R46): Replaced `ErrorHandling` with `SendErrorMessage` in the `CloseEventWebsocket` function. [[1]](diffhunk://#diff-7df8a2388e8a257f69ef2bd4a9adfc7a9b25a20f8f71907650cc7c7ddc72463aL32-R46) [[2]](diffhunk://#diff-7df8a2388e8a257f69ef2bd4a9adfc7a9b25a20f8f71907650cc7c7ddc72463aL55-R55) [[3]](diffhunk://#diff-7df8a2388e8a257f69ef2bd4a9adfc7a9b25a20f8f71907650cc7c7ddc72463aL66-R72) [[4]](diffhunk://#diff-7df8a2388e8a257f69ef2bd4a9adfc7a9b25a20f8f71907650cc7c7ddc72463aL83-R90)
* [`src/features/v2ws/discardEventWebsocket.go`](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L47-R50): Replaced `ErrorHandling` with `SendErrorMessage` in the `DiscardCardsEventWebsocket` function. [[1]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L47-R50) [[2]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L56-R59) [[3]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L65-R83) [[4]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L101-R110)

Logging and Error Message Handling:

* [`src/features/v2ws/discardEventWebsocket.go`](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L7): Removed `log.Fatalf` statements and replaced them with error message creation and sending to the client. [[1]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L7) [[2]](diffhunk://#diff-1f55f2109d27976d5908683bcd12879941aa93f8bf6b80e20fb4d322352237a6L26-R35)
* [`src/features/v2ws/importSingleCardEventWebsocket.go`](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL7-R8): Removed `log.Fatalf` statements and replaced them with error message creation and sending to the client. [[1]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL7-R8) [[2]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL25-R35) [[3]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL47-R51) [[4]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL58-R62) [[5]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL68-R88) [[6]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL102-R106) [[7]](diffhunk://#diff-9a57035c7e07c7af3fb72b966b4a7a28f9ea7cb31c9cfe7a115d694a8b4a831eL117-R121)
* [`src/features/v2ws/itemChangeEventWebsocket.go`](diffhunk://#diff-2457c67cc66b85a3f683a3fc00c1f23c0b09dcb0415fcca84d46bea1aafb0a9cL7-R8): Removed `log.Fatalf` statements and replaced them with error message creation and sending to the client. [[1]](diffhunk://#diff-2457c67cc66b85a3f683a3fc00c1f23c0b09dcb0415fcca84d46bea1aafb0a9cL7-R8) [[2]](diffhunk://#diff-2457c67cc66b85a3f683a3fc00c1f23c0b09dcb0415fcca84d46bea1aafb0a9cL25-R35) [[3]](diffhunk://#diff-2457c67cc66b85a3f683a3fc00c1f23c0b09dcb0415fcca84d46bea1aafb0a9cL47-R51) [[4]](diffhunk://#diff-2457c67cc66b85a3f683a3fc00c1f23c0b09dcb0415fcca84d46bea1aafb0a9cL56-R67)
* [`src/features/v2ws/joinPlayEvenetWebsocket.go`](diffhunk://#diff-6dac8ce17b26b1298f2b825f3f2bd124acbf41d638c8f689ef76c517ecb994d9L7): Removed `log.Fatalf` statements and replaced them with error message creation and sending to the client. [[1]](diffhunk://#diff-6dac8ce17b26b1298f2b825f3f2bd124acbf41d638c8f689ef76c517ecb994d9L7) [[2]](diffhunk://#diff-6dac8ce17b26b1298f2b825f3f2bd124acbf41d638c8f689ef76c517ecb994d9L23-R32) [[3]](diffhunk://#diff-6dac8ce17b26b1298f2b825f3f2bd124acbf41d638c8f689ef76c517ecb994d9L38-R62)