### PR TITLE
{improvement} - 재연결 시간 개선 \N #533

### DIFF
--- a/src/features/v2ws/abnormalEventUseCase.go
+++ b/src/features/v2ws/abnormalEventUseCase.go
@@ -12,12 +12,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// 재접속 대기 타이머 (10초)
+// 재접속 대기 타이머 (20초)
 func waitForReconnection(roomID uint, sessionID string, preloadUsers []entity.RoomUsers) {
 	fmt.Printf("Waiting for session %s to reconnect in room %d...\n", sessionID, roomID)
 
 	// 타이머 설정
-	timer := time.AfterFunc(10*time.Second, func() {
+	timer := time.AfterFunc(20*time.Second, func() {
 		// `entity.WSClients`에서 sessionID가 존재하는지 확인
 		if _, exists := entity.WSClients[sessionID]; !exists {
 			fmt.Printf("Session %s does not exist in WSClients. Skipping cleanup.\n", sessionID)

--- a/src/features/v2ws/websocket.go
+++ b/src/features/v2ws/websocket.go
@@ -25,13 +25,13 @@ reconnectTime : 클라이언트가 연결을 잃었을 때 다시 연결을 시�
 */
 const (
 	// 클라이언트에 메시지를 쓸 수 있는 시간입니다.
-	WriteWait = 3 * time.Second // Ping 메시지 전송 타임아웃
+	WriteWait = 5 * time.Second // 3~5초
 
 	// 클라이언트로부터 다음 퐁 메시지를 읽을 수 있는 시간입니다.
-	PongWait = 15 * time.Second // 더 긴 연결 유지 허용
+	PongWait = 20 * time.Second // 15~30초
 
 	// 핑을 보낼 수 있는 주기입니다. (PongWait보다 짧아야 함)
-	PingPeriod = 5 * time.Second // Ping 간격 (PongWait보다 짧게 설정)
+	PingPeriod = 7 * time.Second // PongWait의 1/3~1/2
 )
 
 func WSHandleMessages(gameName string) {

--- a/src/features/ws/abnormalEventUseCase.go
+++ b/src/features/ws/abnormalEventUseCase.go
@@ -12,12 +12,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// 재접속 대기 타이머 (30초)
+// 재접속 대기 타이머 (20초)
 func waitForReconnection(roomID uint, sessionID string, preloadUsers []entity.RoomUsers) {
 	fmt.Printf("Waiting for session %s to reconnect in room %d...\n", sessionID, roomID)
 
 	// 타이머 설정
-	timer := time.AfterFunc(10*time.Second, func() {
+	timer := time.AfterFunc(20*time.Second, func() {
 
 		// `entity.WSClients`에서 sessionID가 존재하는지 확인
 		if _, exists := entity.WSClients[sessionID]; !exists {

--- a/src/features/ws/websocket.go
+++ b/src/features/ws/websocket.go
@@ -17,13 +17,13 @@ import (
 
 const (
 	// 클라이언트에 메시지를 쓸 수 있는 시간입니다.
-	WriteWait = 3 * time.Second // Ping 메시지 전송 타임아웃
+	WriteWait = 5 * time.Second // 3~5초
 
 	// 클라이언트로부터 다음 퐁 메시지를 읽을 수 있는 시간입니다.
-	PongWait = 15 * time.Second // 더 긴 연결 유지 허용
+	PongWait = 20 * time.Second // 15~30초
 
 	// 핑을 보낼 수 있는 주기입니다. (PongWait보다 짧아야 함)
-	PingPeriod = 5 * time.Second // Ping 간격 (PongWait보다 짧게 설정)
+	PingPeriod = 7 * time.Second // PongWait의 1/3~1/2
 )
 
 func WSHandleMessages(gameName string) {


### PR DESCRIPTION
This pull request includes changes to the reconnection timers and ping/pong intervals in the WebSocket handling code to improve connection stability.

### Changes to reconnection timers:

* [`src/features/v2ws/abnormalEventUseCase.go`](diffhunk://#diff-8e34c975e6afd874c24641283d07aff79980c335495c58df92abf5f425858d95L15-R20): Increased the reconnection wait timer from 10 seconds to 20 seconds.
* [`src/features/ws/abnormalEventUseCase.go`](diffhunk://#diff-c34a02224f21aa0564b4854d1a46d5872f61da235e1f5493ecc5e06fb7e5b10fL15-R20): Increased the reconnection wait timer from 10 seconds to 20 seconds.

### Changes to ping/pong intervals:

* [`src/features/v2ws/websocket.go`](diffhunk://#diff-35c353a91ef64e2c9faec2235637c712b0538f6c6df064b2ab0fef6cc044c8d9L28-R34): Increased `WriteWait` from 3 seconds to 5 seconds, `PongWait` from 15 seconds to 20 seconds, and `PingPeriod` from 5 seconds to 7 seconds.
* [`src/features/ws/websocket.go`](diffhunk://#diff-4bc62be26bc650597be412b5a2ace240bdfa9ca8a41085fa9538e042b79e5acbL20-R26): Increased `WriteWait` from 3 seconds to 5 seconds, `PongWait` from 15 seconds to 20 seconds, and `PingPeriod` from 5 seconds to 7 seconds.