### PR TITLE
{fix} - 유저 플레이 상태 disconnected 로 통일 \n #538

### DIFF
--- a/src/features/ws/repository/abnormalEventWebsocketRepository.go
+++ b/src/features/ws/repository/abnormalEventWebsocketRepository.go
@@ -62,7 +62,7 @@ func AbnormalUpdateUsers(ctx context.Context, tx *gorm.DB, abnormalEntity *entit
 	if err := tx.Model(&mysql.FrogRoomUsers{}).
 		Where("room_id = ?", abnormalEntity.RoomID).
 		Where("user_id = ?", abnormalEntity.AbnormalUserID).
-		Update("player_state", "disconnect").Error; err != nil {
+		Update("player_state", "disconnected").Error; err != nil {
 		return &entity.ErrorInfo{
 			Code: _errors.ErrCodeInternal,
 			Msg:  "유저 상태 변경 실패",


### PR DESCRIPTION
This pull request includes a small but important change to the `AbnormalUpdateUsers` function in the `abnormalEventWebsocketRepository.go` file. The change updates the `player_state` value from "disconnect" to "disconnected" to ensure consistency and correctness.

* [`src/features/ws/repository/abnormalEventWebsocketRepository.go`](diffhunk://#diff-f9a96057e7cc77d7f07922c2e1f6a4d2d60ce5cecde077608626d8b8a6a57e49L65-R65): Modified the `Update` method to change the `player_state` value from "disconnect" to "disconnected" in the `AbnormalUpdateUsers` function.