### PR TITLE
{fix} - 마지막 랜덤 선택시 이슈 해결 \n

### DIFF
--- a/src/features/v2ws/repository/randomEventWebsocketRepository.go
+++ b/src/features/v2ws/repository/randomEventWebsocketRepository.go
@@ -40,7 +40,7 @@ func RandomUpdateRandomCards(ctx context.Context, tx *gorm.DB, randomEntity *ent
 	var cardIDs []int
 	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 		Model(&mysql.UserBirdCards{}).
-		Where("room_id = ? AND state = ?", randomEntity.RoomID, "none").
+		Where("room_id = ? AND state IN ?", randomEntity.RoomID, []string{"opened", "none"}).
 		Order("RAND()").
 		Limit(int(randomEntity.Count)).
 		Pluck("card_id", &cardIDs).Error


### PR DESCRIPTION
This pull request includes a change to the `RandomUpdateRandomCards` function in the `randomEventWebsocketRepository.go` file. The change updates the query condition to include an additional card state.

Query condition update:

* [`src/features/v2ws/repository/randomEventWebsocketRepository.go`](diffhunk://#diff-5840c77edd6edad212fee0047f8b37073f8bfa62e7df9cc1441250e253ffac1eL43-R43): Modified the `Where` clause to include the card state "opened" in addition to "none" when selecting cards.