### PR TITLE
{fix} - 론 성공시 코인 추가 로직 제거 \n #545

### DIFF
--- a/src/features/ws/successLoanEventWebsocket.go
+++ b/src/features/ws/successLoanEventWebsocket.go
@@ -56,16 +56,6 @@ func SuccessLoanEventWebsocket(msg *entity.WSMessage) *entity.ErrorInfo {
 		if errInfo != nil {
 			return fmt.Errorf("%s", errInfo.Msg)
 		}
-		// 론인 경우 해당 유저에 코인 차감한다.
-		errInfo = repository.SuccessLoanDiffCoin(ctx, tx, &successEntity)
-		if errInfo != nil {
-			return fmt.Errorf("%s", errInfo.Msg)
-		}
-		// 론인 경우 해당 유저에 코인 추가한다.
-		errInfo = repository.SuccessLoanAddCoin(ctx, tx, &successEntity)
-		if errInfo != nil {
-			return fmt.Errorf("%s", errInfo.Msg)
-		}
 
 		// 유저 상태 변경
 		errInfo = repository.SuccessUpdateRoomUsers(ctx, tx, &successEntity)


### PR DESCRIPTION
This pull request includes a significant change to the `SuccessLoanEventWebsocket` function in the `src/features/ws/successLoanEventWebsocket.go` file. The main change involves the removal of coin deduction and addition logic for users during a successful loan event.

Codebase simplification:

* [`src/features/ws/successLoanEventWebsocket.go`](diffhunk://#diff-db604894edcb769b2d2a64b1594f119a79e47464f5b284e081789cb0a71a07ddL59-L68): Removed the logic for deducting and adding coins to users during a successful loan event, simplifying the `SuccessLoanEventWebsocket` function.